### PR TITLE
Render text using draw commands

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,7 +1,10 @@
 use vitae::prelude::*;
 
 pub fn main() {
-    let root = div().size(FULL).bg(RED).child(div().size(px(400.)));
+    let root = div()
+        .size(FULL)
+        .bg(RED)
+        .child(div().size(px(400.)).child(text("Hello from Vitae")));
 
     let app = App::new(root);
 


### PR DESCRIPTION
## Summary
- load bundled Inter font and track text items
- convert DrawCommand::Text into glyphon buffers
- demo text rendering in hello example

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68af9c2a2f248331ad07a4a6dd475a4d